### PR TITLE
[11] Initializing attribute `SignalSource::_canBeReset`

### DIFF
--- a/AdventOfCode2015/Day7/Day7.cpp
+++ b/AdventOfCode2015/Day7/Day7.cpp
@@ -1,8 +1,6 @@
 #include <fstream>
 #include <iostream>
-#include <memory>
 #include <string>
-#include <vector>
 
 #include "SignalSource/SignalSource.hpp"
 #include "SignalSource/OperationBitBool.hpp"

--- a/AdventOfCode2015/Day7/SignalSource/RawSignal.cpp
+++ b/AdventOfCode2015/Day7/SignalSource/RawSignal.cpp
@@ -1,10 +1,8 @@
 #include "RawSignal.hpp"
 
 RawSignal::RawSignal(const std::string& pDestinationWireName, int pValue) :
-	SignalSource(pDestinationWireName, pValue)
-{
-	_canBeReset = false;
-}
+	SignalSource(pDestinationWireName, pValue, false)
+{}
 
 wireSig RawSignal::calculateValue(const wireSigMap& pWireSignals)
 {

--- a/AdventOfCode2015/Day7/SignalSource/SignalSource.cpp
+++ b/AdventOfCode2015/Day7/SignalSource/SignalSource.cpp
@@ -2,11 +2,11 @@
 
 SignalSource::SignalSource(
 	const std::string& pDestinationWireName,
-	wireSig pValue) :
+	wireSig pValue, bool pCanBeReset) :
 	_destinationWireName(pDestinationWireName),
 	_value(pValue),
 	_isValueSet(true),
-	_canBeReset(true)
+	_canBeReset(pCanBeReset)
 {}
 
 void SignalSource::setValue(wireSig pValue)

--- a/AdventOfCode2015/Day7/SignalSource/SignalSource.cpp
+++ b/AdventOfCode2015/Day7/SignalSource/SignalSource.cpp
@@ -1,10 +1,12 @@
 #include "SignalSource.hpp"
 
-SignalSource::SignalSource(const std::string& pDestinationWireName) :
+SignalSource::SignalSource(
+	const std::string& pDestinationWireName,
+	bool pCanBeReset) :
 	_destinationWireName(pDestinationWireName),
 	_value(DEFAULT_VALUE),
 	_isValueSet(false),
-	_canBeReset(true)
+	_canBeReset(pCanBeReset)
 {}
 
 SignalSource::SignalSource(

--- a/AdventOfCode2015/Day7/SignalSource/SignalSource.cpp
+++ b/AdventOfCode2015/Day7/SignalSource/SignalSource.cpp
@@ -1,5 +1,12 @@
 #include "SignalSource.hpp"
 
+SignalSource::SignalSource(const std::string& pDestinationWireName) :
+	_destinationWireName(pDestinationWireName),
+	_value(DEFAULT_VALUE),
+	_isValueSet(false),
+	_canBeReset(true)
+{}
+
 SignalSource::SignalSource(
 	const std::string& pDestinationWireName,
 	wireSig pValue,
@@ -20,13 +27,6 @@ void SignalSource::setValue(wireSig pValue)
 	_value = pValue;
 	_isValueSet = true;
 }
-
-SignalSource::SignalSource(const std::string& pDestinationWireName) :
-	_destinationWireName(pDestinationWireName),
-	_value(DEFAULT_VALUE),
-	_isValueSet(false),
-	_canBeReset(true)
-{}
 
 const std::string& SignalSource::getDestinationWireName() const
 {

--- a/AdventOfCode2015/Day7/SignalSource/SignalSource.cpp
+++ b/AdventOfCode2015/Day7/SignalSource/SignalSource.cpp
@@ -9,6 +9,11 @@ SignalSource::SignalSource(
 	_canBeReset(pCanBeReset)
 {}
 
+wireSig SignalSource::getValue() const
+{
+	return _value;
+}
+
 void SignalSource::setValue(wireSig pValue)
 {
 	_value = pValue;
@@ -22,19 +27,14 @@ SignalSource::SignalSource(const std::string& pDestinationWireName) :
 	_canBeReset(true)
 {}
 
-wireSig SignalSource::getValue() const
+const std::string& SignalSource::getDestinationWireName() const
 {
-	return _value;
+	return _destinationWireName;
 }
 
 bool SignalSource::isValueSet() const
 {
 	return _isValueSet;
-}
-
-const std::string& SignalSource::getDestinationWireName() const
-{
-	return _destinationWireName;
 }
 
 void SignalSource::resetValue()

--- a/AdventOfCode2015/Day7/SignalSource/SignalSource.cpp
+++ b/AdventOfCode2015/Day7/SignalSource/SignalSource.cpp
@@ -2,7 +2,8 @@
 
 SignalSource::SignalSource(
 	const std::string& pDestinationWireName,
-	wireSig pValue, bool pCanBeReset) :
+	wireSig pValue,
+	bool pCanBeReset) :
 	_destinationWireName(pDestinationWireName),
 	_value(pValue),
 	_isValueSet(true),

--- a/AdventOfCode2015/Day7/SignalSource/SignalSource.hpp
+++ b/AdventOfCode2015/Day7/SignalSource/SignalSource.hpp
@@ -17,6 +17,7 @@ private:
 	bool _canBeReset;
 
 protected:
+	SignalSource(const std::string& pDestinationWireName);
 	SignalSource(
 		const std::string& pDestinationWireName,
 		wireSig pValue,
@@ -26,8 +27,6 @@ protected:
 	void setValue(wireSig pValue);
 
 public:
-	SignalSource(const std::string& pDestinationWireName);
-
 	virtual wireSig calculateValue(
 		const std::map<std::string,
 		std::shared_ptr<SignalSource>>&pWireSignals) = 0;

--- a/AdventOfCode2015/Day7/SignalSource/SignalSource.hpp
+++ b/AdventOfCode2015/Day7/SignalSource/SignalSource.hpp
@@ -14,10 +14,9 @@ private:
 	std::string _destinationWireName;
 	wireSig _value;
 	bool _isValueSet;
-
-protected:
 	bool _canBeReset;
 
+protected:
 	SignalSource(
 		const std::string& pDestinationWireName,
 		wireSig pValue,

--- a/AdventOfCode2015/Day7/SignalSource/SignalSource.hpp
+++ b/AdventOfCode2015/Day7/SignalSource/SignalSource.hpp
@@ -17,7 +17,9 @@ private:
 	bool _canBeReset;
 
 protected:
-	SignalSource(const std::string& pDestinationWireName);
+	SignalSource(
+		const std::string& pDestinationWireName,
+		bool pCanBeReset = true);
 	SignalSource(
 		const std::string& pDestinationWireName,
 		wireSig pValue,

--- a/AdventOfCode2015/Day7/SignalSource/SignalSource.hpp
+++ b/AdventOfCode2015/Day7/SignalSource/SignalSource.hpp
@@ -18,7 +18,10 @@ private:
 protected:
 	bool _canBeReset;
 
-	SignalSource(const std::string& pDestinationWireName, wireSig pValue);
+	SignalSource(
+		const std::string& pDestinationWireName,
+		wireSig pValue,
+		bool pCanBeReset=true);
 
 	wireSig getValue() const;
 	void setValue(wireSig pValue);

--- a/AdventOfCode2015/Day7/SignalSource/SignalSource.hpp
+++ b/AdventOfCode2015/Day7/SignalSource/SignalSource.hpp
@@ -28,11 +28,11 @@ protected:
 public:
 	SignalSource(const std::string& pDestinationWireName);
 
-	const std::string& getDestinationWireName() const;
-
 	virtual wireSig calculateValue(
 		const std::map<std::string,
-		std::shared_ptr<SignalSource>>& pWireSignals) = 0;
+		std::shared_ptr<SignalSource>>&pWireSignals) = 0;
+
+	const std::string& getDestinationWireName() const;
 
 	bool isValueSet() const;
 	void resetValue();


### PR DESCRIPTION
In project `Day7`, both constructors of `SignalSource` can set attribute `_canBeReset`. The public constructor has become protected. Attribute `_canBeReset` has become private.

Close #11